### PR TITLE
Added EtTriggeredSend::EtClientId property in order to generate valid SO...

### DIFF
--- a/src/druid628/exactTarget/EtTriggeredSend.php
+++ b/src/druid628/exactTarget/EtTriggeredSend.php
@@ -19,6 +19,8 @@ class EtTriggeredSend extends EtBaseClass
 {
 
     protected $client;
+
+    public $Client; // EtClientID
     public $TriggeredSendDefinition; // EtTriggeredSendDefinition
     public $Subscribers; // EtSubscriber
     public $Attributes; // EtAttribute


### PR DESCRIPTION
My SOAP calls need subaccount client ID:

https://help.exacttarget.com/fr-FR/technical_library/web_service_guide/technical_articles/reviewing_soap_envelopes_to_retrieve_information/

NOTE: The SOAP envelopes include a client ID value that can be used to perform calls in sub-accounts, such as in an Enterprise 2.0 account. If you are performing the action in the same account you are logged into, you do not need to include this value.

```
<SOAP-ENV:Body>
    <ns1:CreateRequest>
        <ns1:Options/>
        <ns1:Objects xsi:type="ns1:TriggeredSend">
            <ns1:Client>
                <ns1:ID>********2</ns1:ID>
            </ns1:Client>
```

In order to generate a correct XML in EtSoapClient, I added this property inside EtTriggeredSend:

```
public $Client; // EtClientID
```

This does not collide with EtTriggeredSend::client (class properties are case sensitive).
