### PR TITLE
Fix invalid var in update exception

### DIFF
--- a/src/druid628/exactTarget/EtClient.php
+++ b/src/druid628/exactTarget/EtClient.php
@@ -281,7 +281,7 @@ class EtClient extends EtBaseClass
         $results = $this->client->Update($request);
 
         if ($results->OverallStatus != 'OK') {
-            throw new EtSoapException($results->Results->ErrorMessage, $results->Results->ErrorCode);
+            throw new EtSoapException($results->Results->StatusMessage, $results->Results->ErrorCode);
         }
 
         $updatedClass = $this->cast($results->Results->Object, new $nsClass($this), $this);


### PR DESCRIPTION
If an update fails, it throws an EtSoapException, but the ErrorMessage attribute does not exist, it needs to use StatusMessage as per the other methods. This PR fixes that.